### PR TITLE
[#] 修复string to char*导致的乱码

### DIFF
--- a/src/carrotjuicer/notifier.cpp
+++ b/src/carrotjuicer/notifier.cpp
@@ -25,7 +25,7 @@ namespace notifier
 		httplib::Error error = res.error();
 		if (error != httplib::Error::Success)
 		{
-			printf("Unexpected error from notifier: %s \n", httplib::to_string(error));
+			std::cout << "Unexpected error from notifier: " << httplib::to_string(error) << "\n";
 		}
 	}
 	void notify_request(const std::string& data)
@@ -38,7 +38,7 @@ namespace notifier
 		httplib::Error error = res.error();
 		if (error != httplib::Error::Success)
 		{
-			printf("Unexpected error from notifier: %s \n", httplib::to_string(error));
+			std::cout << "Unexpected error from notifier: " << httplib::to_string(error) << "\n";
 		}
 	}
 }


### PR DESCRIPTION
由于printf没有对变长参数作类型检查，会导致httplib.to_string返回的String类在打印时按char*处理
![image](https://user-images.githubusercontent.com/48101337/175773789-4eae87fe-98cb-4e5f-a51c-fe3b5262e8b9.png)
